### PR TITLE
Fix bug not remove child private field

### DIFF
--- a/helpers/normalize-id.js
+++ b/helpers/normalize-id.js
@@ -9,8 +9,4 @@ module.exports = function normalizeId(ret) {
       ret.id = ret._id.toString();
     }
   }
-// Do not remove _id
-//   if (typeof ret._id !== 'undefined') {
-//     delete ret._id;
-//   }
 };

--- a/helpers/normalize-id.js
+++ b/helpers/normalize-id.js
@@ -9,7 +9,8 @@ module.exports = function normalizeId(ret) {
       ret.id = ret._id.toString();
     }
   }
-  if (typeof ret._id !== 'undefined') {
-    delete ret._id;
-  }
+// Do not remove _id
+//   if (typeof ret._id !== 'undefined') {
+//     delete ret._id;
+//   }
 };

--- a/helpers/remove-private-paths.js
+++ b/helpers/remove-private-paths.js
@@ -1,13 +1,15 @@
 'use strict';
 
+const dotProp = require('dot-prop');
+
 /**
  * Helper to remove private paths
  */
 module.exports = function removePrivatePaths(ret, schema) {
   for (const path in schema.paths) {
     if (schema.paths[path].options && schema.paths[path].options.private) {
-      if (typeof ret[path] !== 'undefined') {
-        delete ret[path];
+      if (typeof dotProp.get(ret, path) !== 'undefined') {
+        dotProp.delete(ret, path);
       }
     }
   }

--- a/helpers/remove-underscore-id.js
+++ b/helpers/remove-underscore-id.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * Helper to remove _id
+ */
+module.exports = function removeUnderscoreId(ret) {
+  if (typeof ret._id !== 'undefined') {
+    delete ret._id;
+  }
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  * Load helpers
  */
 const normalizeId = require('./helpers/normalize-id');
+const removeUnderscoreId = require('./helpers/remove-underscore-id');
 const removeVersion = require('./helpers/remove-version');
 const removePrivatePaths = require('./helpers/remove-private-paths');
 
@@ -39,11 +40,16 @@ module.exports = function toJSON(schema) {
         normalizeId(ret);
       }
 
+      //Remove _id
+      if (schema.options.removeUnderscoreId === true) {
+        removeUnderscoreId(ret);
+      }
+
       //Call custom transform if present
       if (transform) {
         return transform(doc, ret, options);
       }
-      
+
       return ret;
     },
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@meanie/mongoose-to-json",
+  "name": "@taina/mongoose-to-json",
   "description": "A plugin for Mongoose to normalize JSON output",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "homepage": "https://github.com/meanie/mongoose-to-json",
   "author": {
     "name": "Adam Reis",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   },
   "peerDependencies": {
     "mongoose": "^4.11.9 || ^5.0.3"
+  },
+  "dependencies": {
+    "dot-prop": "^5.3.0"
   }
 }


### PR DESCRIPTION
Fixing bug in case that private field in child field.

For example:
```
const thisSchema = new Schema({
  parent: {
    child: {
      type: [String],
      private: true,
    }
  },
}, options);
```

When calling .toJSON(), child still appear because current removePrivatePaths trying to access ret['parent.child'] instead of ret.parent.child
